### PR TITLE
Combined Main_ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,121 @@
+source/CMakeFiles
+source/Makefile
+source/PhoenixDoom
+source/cmake_install.cmake
+third_party_libs/libsdl/CMakeFiles
+third_party_libs/libsdl/Makefile
+third_party_libs/libsdl/cmake_install.cmake
+third_party_libs/libsdl/libSDL.a
+# Compiled Object files
+*.slo
+# Compiled Dynamic libraries
+# Fortran module files
+*.mod
+*.smod
+# Compiled Static libraries
+*.lai
+# Prerequisites
+*.d
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+# Linker output
+*.ilk
+*.map
+*.exp
+# Precompiled Headers
+*.gch
+*.pch
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+## User settings
+xcuserdata/
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+## Obj-C/Swift specific
+*.hmap
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+Carthage/Build/
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+iOSInjectionProject/

--- a/source/Audio/AudioLoader.cpp
+++ b/source/Audio/AudioLoader.cpp
@@ -7,6 +7,7 @@
 #include "Base/Mem.h"
 #include "Game/GameDataFS.h"
 #include <vector>
+#include <limits>
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 // Some ids expected in AIFF-C and AIFF files

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -183,16 +183,17 @@ set(SOURCE_FILES
 set(OTHER_FILES
 )
 
-# Platform specific sources
-if (PLATFORM_WINDOWS)
-    #list(APPEND SOURCE_FILES "Main_Windows.cpp")
-elseif(PLATFORM_MAC)
+# Platform specific command line arguments
+if (PLATFORM_MAC)
     #list(APPEND SOURCE_FILES "Main_Mac.mm")
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-x>)
-    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:objective-c++>)
-
-else()
-    #list(APPEND SOURCE_FILES "Main_StandardCpp.cpp")
+    if (COMPILER_GCC) 
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-x>)
+    elseif(COMPILER_CLANG)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:--language>)
+    endif()
+    if (COMPILER_GCC OR COMPILER_CLANG)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:objective-c++>)
+    endif()
 endif()
 
 # Platform and compiler specific defines

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -177,6 +177,7 @@ set(SOURCE_FILES
     "UI/UIUtils.h"
     "UI/WipeFx.cpp"
     "UI/WipeFx.h"
+    "Main.cpp"
 )
 
 set(OTHER_FILES
@@ -184,11 +185,14 @@ set(OTHER_FILES
 
 # Platform specific sources
 if (PLATFORM_WINDOWS)
-    list(APPEND SOURCE_FILES "Main_Windows.cpp")
+    #list(APPEND SOURCE_FILES "Main_Windows.cpp")
 elseif(PLATFORM_MAC)
-    list(APPEND SOURCE_FILES "Main_Mac.mm")
+    #list(APPEND SOURCE_FILES "Main_Mac.mm")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-x>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:objective-c++>)
+
 else()
-    list(APPEND SOURCE_FILES "Main_StandardCpp.cpp")
+    #list(APPEND SOURCE_FILES "Main_StandardCpp.cpp")
 endif()
 
 # Platform and compiler specific defines

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -1,6 +1,5 @@
 #include "Game/DoomMain.h"
-
-#define WIN32_LEAN_AND_MEAN
+#if WIN32
 #include <Windows.h>
 
 int WINAPI wWinMain(
@@ -9,6 +8,12 @@ int WINAPI wWinMain(
     [[maybe_unused]] LPWSTR lpCmdLine,
     [[maybe_unused]] int nCmdShow
 ) {
+#else 
+int main(int argc, char* argv[]) noexcept {
+#endif
+#if APPLE
+    @autoreleasepool {
+#endif
     D_DoomMain();
     return 0;
 }

--- a/source/Main_Mac.mm
+++ b/source/Main_Mac.mm
@@ -1,9 +1,0 @@
-#include "Game/DoomMain.h"
-
-int main(int argc, char* argv[]) noexcept {
-    @autoreleasepool {
-        D_DoomMain();
-    }
-
-    return 0;
-}

--- a/source/Main_StandardCpp.cpp
+++ b/source/Main_StandardCpp.cpp
@@ -1,6 +1,0 @@
-#include "Game/DoomMain.h"
-
-int main() noexcept {
-    D_DoomMain();
-    return 0;
-}


### PR DESCRIPTION
and fixed missing include in Audio/AudioLoader.cpp

gcc and clang include an option to use objective-c++ even when the extension is cpp. I've changed the Main_ files to use preprocessor definitions and add_compile_options in cmake to use objective-c++ under MacOS.